### PR TITLE
Add pyproject with project metadata and ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "rl-capstone"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+    "numpy",
+    "pillow",
+    "opencv-python",
+    "pygame",
+    "gym",
+    "tensorflow-macos; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "tensorflow-metal; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "keras",
+    "matplotlib",
+    "tqdm",
+]
+
+[project.optional-dependencies]
+dev = ["ruff"]
+
+[tool.ruff]
+line-length = 120
+select = ["E", "F"]


### PR DESCRIPTION
## Summary
- add a basic `pyproject.toml` with project metadata
- list runtime dependencies and a dev dependency for `ruff`
- configure ruff line length and rule selection

## Testing
- `python -m py_compile $(git ls-files '*.py')`