### PR TITLE
Add uv setup script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ Reinforcement Learning Project
 - Tetris
 - Simple Maze Game
 
+### Setup
+
+Install dependencies with [uv](https://github.com/astral-sh/uv). The project
+provides a `uv.lock` file for reproducible installations. Running the following
+command installs the locked packages and the project itself:
+```
+uv pip install --system -e .
+```
+
+Codex disables network access after the setup phase, so place the above command
+in a `setup.sh` script to ensure packages are available when the environment goes
+offline.
+
 ### Usage
 
 Run `python blob.py` to see the maze game demo.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies using uv and the provided lock file
+uv pip install --system -e .


### PR DESCRIPTION
## Summary
- document uv-based setup instructions in the README
- add `setup.sh` to install dependencies with uv

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
